### PR TITLE
Preparing for release

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,6 +2,13 @@
 name = "rsgm"
 version = "0.1.0"
 edition = "2021"
+license = "MIT"
+description = "A small library for importing Bayesian networks into Rust."
+homepage = "https://github.com/neuppl/rsgm/" # eventually: neuppl site!
+repository = "https://github.com/neuppl/rsgm/"
+keywords = ["bayesian", "networks", "decision-diagrams", "bayesian-networks"]
+categories = ["data-structures", "encoding"]
+readme = "README.md"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 [lib]

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
-# Summary
+# rsgm
 
-A small library for importing Bayesian networks into Rust
+A small library for importing Bayesian networks into Rust. Primarily
+used for research purposes and for [rsdd](https://github.com/neuppl/rsdd).
 
 ## Usage
 
@@ -14,7 +15,115 @@ To use it, first install the `pgmpy` python package. Then, it can be invoked as:
 python bif_to_json.py input.bif > output.json
 ```
 
-### rsgm
+### Bayesian Networks
 
 The RSGM library contains tools for parsing and manipulating Bayesian networks
-from a JSON representation.
+from a JSON representation. The example in the `examples` directory provides
+the most basic example to do so; this simply prints the JSON representation.
+
+```
+cargo run --example rsbn -- -f bayesian_networks/sachs.json
+```
+
+Here is a "kitchen sink" example that showcases the public API:
+
+```rs
+fn test_public_api_e2e() {
+    /// models the collider A, B -> C
+    static NETWORK: &str = r#"{
+        "network": "toy_network",
+        "variables": ["A", "B", "C"],
+        "cpts": {
+            "A": [[0.5], [0.5]],
+            "B": [[0.25], [0.75]],
+            "C": [[0.9, 0.8, 0.3, 0.4], [0.1, 0.2, 0.7, 0.6]]
+        },
+        "states": {
+            "A": ["F", "T"],
+            "B": ["F", "T"],
+            "C": ["F", "T"]
+        },
+        "parents" :{
+            "A": [],
+            "B": [],
+            "C": ["A", "B"]
+        }
+    }"#;
+
+    let bayesian_network = BayesianNetwork::from_json(NETWORK);
+
+    // parents
+    assert!(bayesian_network.parents("A").is_empty());
+    assert!(bayesian_network.parents("B").is_empty());
+    assert_eq!(bayesian_network.parents("C").len(), 2);
+    assert!(bayesian_network.parents("C").iter().any(|s| s == "A"));
+    assert!(bayesian_network.parents("C").iter().any(|s| s == "B"));
+
+    // parent_assignments
+    assert_eq!(
+        bayesian_network.parent_assignments("A"),
+        vec![HashMap::new()]
+    );
+    assert_eq!(
+        bayesian_network.parent_assignments("B"),
+        vec![HashMap::new()]
+    );
+    assert_eq!(bayesian_network.parent_assignments("C").len(), 4);
+    assert!(bayesian_network
+        .parent_assignments("C")
+        .iter()
+        .any(|s| s["A"] == "F" && s["B"] == "F"));
+    assert!(bayesian_network
+        .parent_assignments("C")
+        .iter()
+        .any(|s| s["A"] == "F" && s["B"] == "T"));
+    assert!(bayesian_network
+        .parent_assignments("C")
+        .iter()
+        .any(|s| s["A"] == "T" && s["B"] == "F"));
+    assert!(bayesian_network
+        .parent_assignments("C")
+        .iter()
+        .any(|s| s["A"] == "T" && s["B"] == "T"));
+
+    // variables
+    assert_eq!(bayesian_network.variables().len(), 3);
+    assert!(bayesian_network.variables().iter().any(|s| s == "A"));
+    assert!(bayesian_network.variables().iter().any(|s| s == "B"));
+    assert!(bayesian_network.variables().iter().any(|s| s == "C"));
+
+    // assignments
+    assert_eq!(bayesian_network.all_possible_assignments("A").len(), 2);
+    assert!(bayesian_network
+        .all_possible_assignments("A")
+        .iter()
+        .any(|s| s == "T"));
+    assert!(bayesian_network
+        .all_possible_assignments("A")
+        .iter()
+        .any(|s| s == "F"));
+
+    // conditionals
+    assert_eq!(
+        bayesian_network.conditional_probability("A", "T", &HashMap::from([])),
+        0.5
+    );
+    assert_eq!(
+        bayesian_network.conditional_probability(
+            "C",
+            "T",
+            &HashMap::from([
+                (String::from("A"), String::from("T")),
+                (String::from("B"), String::from("T"))
+            ])
+        ),
+        0.6
+    );
+
+    // topo sort
+    assert_eq!(bayesian_network.topological_sort().len(), 3);
+    assert_eq!(bayesian_network.topological_sort()[0], "A");
+    assert_eq!(bayesian_network.topological_sort()[1], "B");
+    assert_eq!(bayesian_network.topological_sort()[2], "C");
+}
+```

--- a/examples/rsbn.rs
+++ b/examples/rsbn.rs
@@ -19,7 +19,7 @@ struct Args {
 fn main() {
     let args = Args::parse();
     let str = fs::read_to_string(args.file).unwrap();
-    let network = bayesian_network::BayesianNetwork::from_string(&str);
+    let network = bayesian_network::BayesianNetwork::from_json(&str);
     println!("bn: {:?}", network);
     // println!("topo sort: {:?}", network.topological_sort());
     // let parent_assgn = HashMap::from([ (String::from("Erk"), String::from("HIGH")),

--- a/src/bayesian_network.rs
+++ b/src/bayesian_network.rs
@@ -1,10 +1,9 @@
 //! A graphical representation of a Bayesian network
 
+use serde::{Deserialize, Serialize};
 use std::collections::{BTreeMap, HashMap};
 
-use serde::{Deserialize, Serialize};
-
-/// maps each variable name to a CPT table
+/// maps each variable name to a Conditional Probability Table (CPT)
 /// - rows are indexed by the current variable's possible values
 ///   this index comes from the order given in `states`
 /// - columns are indexed by the parent's possible values
@@ -15,15 +14,14 @@ use serde::{Deserialize, Serialize};
 /// Suppose we have a Bayesian network (a) -> (c) <- (b)
 /// - state: {"a" -> ["a1", "a2"], "b" -> ["b1", "b2", "b3"]}
 /// - parents: {"a" -> [], "b" -> [], "c" -> ["a", "b"]}
-/// - cpts: ```{"a" -> [[0.1], [0.9]],        // says "a" has a prior probability  of value "a1" with prob 0.1
+/// - cpts: ```{"a" -> [[0.1], [0.9]],        /// says "a" has a prior probability  of value "a1" with prob 0.1
 ///          "b" -> [[0.3], [0.2], [0.5]],
 ///          "c" -> [[0.1, 0.2, 0.3, 0.4, 0.5, 0.6],
 ///                  [0.9, 0.8, 0.7, 0.6, 0.5, 0.4]]}```
 /// says Pr(c=c1 | a=a1, b=b1) = 0.1
 ///      Pr(c=c1 | a=a2, b=b1) = 0.4
 ///      Pr(c=c1 | a=a1, b=b3) = 0.3
-#[allow(clippy::upper_case_acronyms)]
-type CPT = HashMap<String, Vec<Vec<f64>>>;
+type ConditionalProbabilityTable = HashMap<String, Vec<Vec<f64>>>;
 /// maps each variable name to a list of that variable's possible values
 type States = HashMap<String, Vec<String>>;
 /// maps each variable name to a list of that variable's parents
@@ -33,17 +31,27 @@ type Parents = HashMap<String, Vec<String>>;
 pub struct BayesianNetwork {
     network: String,
     variables: Vec<String>,
-    cpts: CPT,
+    cpts: ConditionalProbabilityTable,
     states: States,
     parents: Parents,
 }
 
 impl BayesianNetwork {
-    pub fn from_string(fname: &str) -> BayesianNetwork {
-        serde_json::from_str(fname).unwrap()
+    /// Generate a Bayesian Network from a JSON string.
+    /// The JSON string needs to have (in JSON types):
+    /// - `network`: `String`
+    /// - `variables`: [String]
+    /// - `cpts`: { String: [[Number]] }
+    /// - `states`: { String: [String] }
+    /// - `parents`: { String: [String] }
+    pub fn from_json(str: &str) -> BayesianNetwork {
+        match serde_json::from_str(str) {
+            Ok(bn) => bn,
+            Err(err) => panic!("Error parsing JSON: {err}"),
+        }
     }
 
-    fn get_state_index(&self, variable: &String, assignment: &String) -> usize {
+    fn state_index(&self, variable: &str, assignment: &str) -> usize {
         let cur_s = self
             .states
             .get(variable)
@@ -56,7 +64,7 @@ impl BayesianNetwork {
             })
     }
 
-    fn get_num_states(&self, variable: &String) -> usize {
+    fn num_states(&self, variable: &str) -> usize {
         let cur_s = self
             .states
             .get(variable)
@@ -65,7 +73,39 @@ impl BayesianNetwork {
     }
 
     /// get a list of all parents for `variable`
-    pub fn get_parents(&self, variable: &String) -> &Vec<String> {
+    /// ```
+    /// use rsgm::bayesian_network::BayesianNetwork;
+    ///
+    /// // models the collider A, B -> C
+    /// static NETWORK: &str = r#"{
+    ///     "network": "toy_network",
+    ///     "variables": ["A", "B", "C"],
+    ///     "cpts": {
+    ///         "A": [[0.5], [0.5]],
+    ///         "B": [[0.25], [0.75]],
+    ///         "C": [[0.9, 0.8, 0.3, 0.4], [0.1, 0.2, 0.7, 0.6]]
+    ///     },
+    ///     "states": {
+    ///         "A": ["F", "T"],
+    ///         "B": ["F", "T"],
+    ///         "C": ["F", "T"]
+    ///     },
+    ///     "parents" :{
+    ///         "A": [],
+    ///         "B": [],
+    ///         "C": ["A", "B"]
+    ///     }
+    /// }"#;
+    ///
+    /// let bayesian_network = BayesianNetwork::from_json(NETWORK);
+    ///
+    /// assert!(bayesian_network.parents("A").is_empty());
+    /// assert!(bayesian_network.parents("B").is_empty());
+    /// assert_eq!(bayesian_network.parents("C").len(), 2);
+    /// assert!(bayesian_network.parents("C").iter().any(|s| s == "A"));
+    /// assert!(bayesian_network.parents("C").iter().any(|s| s == "B"));
+    /// ```
+    pub fn parents(&self, variable: &str) -> &Vec<String> {
         &self.parents[variable]
     }
 
@@ -76,7 +116,7 @@ impl BayesianNetwork {
 
         let mut r: Vec<HashMap<String, String>> = Vec::new();
         let p = cur_parents.pop().unwrap();
-        let cur_values = self.get_all_assignments(&p);
+        let cur_values = self.all_possible_assignments(&p);
         let sub = self.parent_h(cur_parents);
 
         // add each assignment onto
@@ -91,28 +131,156 @@ impl BayesianNetwork {
     }
 
     /// get a vector of all possible assignments to the parents of this variable
-    pub fn parent_assignments(&self, variable: &String) -> Vec<HashMap<String, String>> {
-        self.parent_h(self.get_parents(variable).clone())
+    /// ```
+    /// use rsgm::bayesian_network::BayesianNetwork;
+    /// use std::collections::HashMap;
+    ///
+    /// // models the collider A, B -> C
+    /// static NETWORK: &str = r#"{
+    ///     "network": "toy_network",
+    ///     "variables": ["A", "B", "C"],
+    ///     "cpts": {
+    ///         "A": [[0.5], [0.5]],
+    ///         "B": [[0.25], [0.75]],
+    ///         "C": [[0.9, 0.8, 0.3, 0.4], [0.1, 0.2, 0.7, 0.6]]
+    ///     },
+    ///     "states": {
+    ///         "A": ["F", "T"],
+    ///         "B": ["F", "T"],
+    ///         "C": ["F", "T"]
+    ///     },
+    ///     "parents" :{
+    ///         "A": [],
+    ///         "B": [],
+    ///         "C": ["A", "B"]
+    ///     }
+    /// }"#;
+    ///
+    /// let bayesian_network = BayesianNetwork::from_json(NETWORK);
+    ///
+    /// assert_eq!(bayesian_network.parent_assignments("A"), vec![HashMap::new()]);
+    /// assert_eq!(bayesian_network.parent_assignments("B"), vec![HashMap::new()]);
+    /// assert_eq!(bayesian_network.parent_assignments("C").len(), 4);
+    /// assert!(bayesian_network.parent_assignments("C").iter().any(|s| s["A"] == "F" && s["B"] == "F"));
+    /// assert!(bayesian_network.parent_assignments("C").iter().any(|s| s["A"] == "F" && s["B"] == "T"));
+    /// assert!(bayesian_network.parent_assignments("C").iter().any(|s| s["A"] == "T" && s["B"] == "F"));
+    /// assert!(bayesian_network.parent_assignments("C").iter().any(|s| s["A"] == "T" && s["B"] == "T"));
+    /// ```
+    pub fn parent_assignments(&self, variable: &str) -> Vec<HashMap<String, String>> {
+        self.parent_h(self.parents(variable).clone())
     }
 
     /// get all variables defined in this Bayesian network
-    pub fn get_variables(&self) -> &Vec<String> {
+    /// ```
+    /// use rsgm::bayesian_network::BayesianNetwork;
+    ///
+    /// // models the collider A, B -> C
+    /// static NETWORK: &str = r#"{
+    ///     "network": "toy_network",
+    ///     "variables": ["A", "B", "C"],
+    ///     "cpts": {
+    ///         "A": [[0.5], [0.5]],
+    ///         "B": [[0.25], [0.75]],
+    ///         "C": [[0.9, 0.8, 0.3, 0.4], [0.1, 0.2, 0.7, 0.6]]
+    ///     },
+    ///     "states": {
+    ///         "A": ["F", "T"],
+    ///         "B": ["F", "T"],
+    ///         "C": ["F", "T"]
+    ///     },
+    ///     "parents" :{
+    ///         "A": [],
+    ///         "B": [],
+    ///         "C": ["A", "B"]
+    ///     }
+    /// }"#;
+    ///
+    /// let bayesian_network = BayesianNetwork::from_json(NETWORK);
+    ///
+    /// assert_eq!(bayesian_network.variables().len(), 3);
+    /// assert!(bayesian_network.variables().iter().any(|s| s == "A"));
+    /// assert!(bayesian_network.variables().iter().any(|s| s == "B"));
+    /// assert!(bayesian_network.variables().iter().any(|s| s == "C"));
+    /// ```
+    pub fn variables(&self) -> &Vec<String> {
         &self.variables
     }
 
     /// get all possible assignments to `variable`
-    pub fn get_all_assignments(&self, variable: &String) -> &Vec<String> {
+    /// ```
+    /// use rsgm::bayesian_network::BayesianNetwork;
+    ///
+    /// // models the collider A, B -> C
+    /// static NETWORK: &str = r#"{
+    ///     "network": "toy_network",
+    ///     "variables": ["A", "B", "C"],
+    ///     "cpts": {
+    ///         "A": [[0.5], [0.5]],
+    ///         "B": [[0.25], [0.75]],
+    ///         "C": [[0.9, 0.8, 0.3, 0.4], [0.1, 0.2, 0.7, 0.6]]
+    ///     },
+    ///     "states": {
+    ///         "A": ["F", "T"],
+    ///         "B": ["F", "T"],
+    ///         "C": ["F", "T"]
+    ///     },
+    ///     "parents" :{
+    ///         "A": [],
+    ///         "B": [],
+    ///         "C": ["A", "B"]
+    ///     }
+    /// }"#;
+    ///
+    /// let bayesian_network = BayesianNetwork::from_json(NETWORK);
+    ///
+    /// assert_eq!(bayesian_network.all_possible_assignments("A").len(), 2);
+    /// assert!(bayesian_network.all_possible_assignments("A").iter().any(|s| s == "T"));
+    /// assert!(bayesian_network.all_possible_assignments("A").iter().any(|s| s == "F"));
+    pub fn all_possible_assignments(&self, variable: &str) -> &Vec<String> {
         &self.states[variable]
     }
 
     /// Get the conditional probability Pr(variable = variable_value | parent_assignment)
-    pub fn get_conditional_prob(
+    /// ```
+    /// use rsgm::bayesian_network::BayesianNetwork;
+    /// use std::collections::HashMap;
+    ///
+    /// // models the collider A, B -> C
+    /// static NETWORK: &str = r#"{
+    ///     "network": "toy_network",
+    ///     "variables": ["A", "B", "C"],
+    ///     "cpts": {
+    ///         "A": [[0.5], [0.5]],
+    ///         "B": [[0.25], [0.75]],
+    ///         "C": [[0.9, 0.8, 0.3, 0.4], [0.1, 0.2, 0.7, 0.6]]
+    ///     },
+    ///     "states": {
+    ///         "A": ["F", "T"],
+    ///         "B": ["F", "T"],
+    ///         "C": ["F", "T"]
+    ///     },
+    ///     "parents" :{
+    ///         "A": [],
+    ///         "B": [],
+    ///         "C": ["A", "B"]
+    ///     }
+    /// }"#;
+    ///
+    /// let bayesian_network = BayesianNetwork::from_json(NETWORK);
+    ///
+    /// assert_eq!(bayesian_network.conditional_probability("A", "T", &HashMap::from([])), 0.5);
+    /// assert_eq!(bayesian_network.conditional_probability("C", "T", &HashMap::from([
+    ///     (String::from("A"), String::from("T")),
+    ///     (String::from("B"), String::from("T"))
+    /// ])), 0.6);
+    /// ```
+    pub fn conditional_probability(
         &self,
-        variable: &String,
-        variable_value: &String,
+        variable: &str,
+        variable_value: &str,
         parent_assignment: &HashMap<String, String>,
     ) -> f64 {
-        let var_idx = self.get_state_index(variable, variable_value);
+        let var_idx = self.state_index(variable, variable_value);
         let row = &self.cpts[variable][var_idx];
         // compute the index into the row
         let parents = self.parents.get(variable).unwrap();
@@ -120,15 +288,47 @@ impl BayesianNetwork {
         let mut idx = 0;
         for parent in parents.iter().rev() {
             let parent_assgn = &parent_assignment[parent];
-            let parent_asggn_idx = self.get_state_index(parent, parent_assgn);
+            let parent_asggn_idx = self.state_index(parent, parent_assgn);
             idx += cur_stride * parent_asggn_idx;
-            let parent_sz = self.get_num_states(parent);
+            let parent_sz = self.num_states(parent);
             cur_stride *= parent_sz;
         }
         row[idx]
     }
 
-    /// Produces a list of variables in topological order
+    /// Produces a list of variables in topological order;
+    /// breaks ties with the order of `variables`
+    /// ```
+    /// use rsgm::bayesian_network::BayesianNetwork;
+    ///
+    /// // models the collider A, B -> C
+    /// static NETWORK: &str = r#"{
+    ///     "network": "toy_network",
+    ///     "variables": ["A", "B", "C"],
+    ///     "cpts": {
+    ///         "A": [[0.5], [0.5]],
+    ///         "B": [[0.25], [0.75]],
+    ///         "C": [[0.9, 0.8, 0.3, 0.4], [0.1, 0.2, 0.7, 0.6]]
+    ///     },
+    ///     "states": {
+    ///         "A": ["F", "T"],
+    ///         "B": ["F", "T"],
+    ///         "C": ["F", "T"]
+    ///     },
+    ///     "parents" :{
+    ///         "A": [],
+    ///         "B": [],
+    ///         "C": ["A", "B"]
+    ///     }
+    /// }"#;
+    ///
+    /// let bayesian_network = BayesianNetwork::from_json(NETWORK);
+    ///
+    /// assert_eq!(bayesian_network.topological_sort().len(), 3);
+    /// assert_eq!(bayesian_network.topological_sort()[0], "A");
+    /// assert_eq!(bayesian_network.topological_sort()[1], "B");
+    /// assert_eq!(bayesian_network.topological_sort()[2], "C");
+    /// ```
     pub fn topological_sort(&self) -> Vec<String> {
         // super naive toposort
         let mut result: Vec<String> = Vec::new();
@@ -161,20 +361,113 @@ impl BayesianNetwork {
 #[test]
 fn test_conditional() {
     let sachs = include_str!("../bayesian_networks/sachs.json");
-    let network = BayesianNetwork::from_string(sachs);
+    let network = BayesianNetwork::from_json(sachs);
     let parent_assgn = HashMap::from([
         (String::from("Erk"), String::from("HIGH")),
         (String::from("PKA"), String::from("AVG")),
     ]);
     assert_eq!(
-        network.get_conditional_prob(&String::from("Akt"), &String::from("LOW"), &parent_assgn),
+        network.conditional_probability(&String::from("Akt"), &String::from("LOW"), &parent_assgn),
         0.177105936
     );
 }
 
 #[test]
-fn test_parent() {
-    let sachs = include_str!("../bayesian_networks/sachs.json");
-    let network = BayesianNetwork::from_string(sachs);
-    println!("{:?}", network.parent_assignments(&String::from("Erk")));
+fn test_public_api_e2e() {
+    /// models the collider A, B -> C
+    static NETWORK: &str = r#"{
+        "network": "toy_network",
+        "variables": ["A", "B", "C"],
+        "cpts": {
+            "A": [[0.5], [0.5]],
+            "B": [[0.25], [0.75]],
+            "C": [[0.9, 0.8, 0.3, 0.4], [0.1, 0.2, 0.7, 0.6]]
+        },
+        "states": {
+            "A": ["F", "T"],
+            "B": ["F", "T"],
+            "C": ["F", "T"]
+        },
+        "parents" :{
+            "A": [],
+            "B": [],
+            "C": ["A", "B"]
+        }
+    }"#;
+
+    let bayesian_network = BayesianNetwork::from_json(NETWORK);
+
+    // parents
+    assert!(bayesian_network.parents("A").is_empty());
+    assert!(bayesian_network.parents("B").is_empty());
+    assert_eq!(bayesian_network.parents("C").len(), 2);
+    assert!(bayesian_network.parents("C").iter().any(|s| s == "A"));
+    assert!(bayesian_network.parents("C").iter().any(|s| s == "B"));
+
+    // parent_assignments
+    assert_eq!(
+        bayesian_network.parent_assignments("A"),
+        vec![HashMap::new()]
+    );
+    assert_eq!(
+        bayesian_network.parent_assignments("B"),
+        vec![HashMap::new()]
+    );
+    assert_eq!(bayesian_network.parent_assignments("C").len(), 4);
+    assert!(bayesian_network
+        .parent_assignments("C")
+        .iter()
+        .any(|s| s["A"] == "F" && s["B"] == "F"));
+    assert!(bayesian_network
+        .parent_assignments("C")
+        .iter()
+        .any(|s| s["A"] == "F" && s["B"] == "T"));
+    assert!(bayesian_network
+        .parent_assignments("C")
+        .iter()
+        .any(|s| s["A"] == "T" && s["B"] == "F"));
+    assert!(bayesian_network
+        .parent_assignments("C")
+        .iter()
+        .any(|s| s["A"] == "T" && s["B"] == "T"));
+
+    // variables
+    assert_eq!(bayesian_network.variables().len(), 3);
+    assert!(bayesian_network.variables().iter().any(|s| s == "A"));
+    assert!(bayesian_network.variables().iter().any(|s| s == "B"));
+    assert!(bayesian_network.variables().iter().any(|s| s == "C"));
+
+    // assignments
+    assert_eq!(bayesian_network.all_possible_assignments("A").len(), 2);
+    assert!(bayesian_network
+        .all_possible_assignments("A")
+        .iter()
+        .any(|s| s == "T"));
+    assert!(bayesian_network
+        .all_possible_assignments("A")
+        .iter()
+        .any(|s| s == "F"));
+
+    // conditionals
+    assert_eq!(
+        bayesian_network.conditional_probability("A", "T", &HashMap::from([])),
+        0.5
+    );
+    assert_eq!(
+        bayesian_network.conditional_probability(
+            "C",
+            "T",
+            &HashMap::from([
+                (String::from("A"), String::from("T")),
+                (String::from("B"), String::from("T"))
+            ])
+        ),
+        0.6
+    );
+
+    // topo sort
+    assert_eq!(bayesian_network.topological_sort().len(), 3);
+    assert_eq!(bayesian_network.topological_sort()[0], "A");
+    assert_eq!(bayesian_network.topological_sort()[1], "B");
+    assert_eq!(bayesian_network.topological_sort()[2], "C");
 }


### PR DESCRIPTION
This PR bundles together various improvements for an alpha release.

- adds doctests for all public functions, and an e2e test for the entire public API
- changes all `&String` parameters to `&str`
- fixes naming conventions to abide by [Rust's API guidelines](https://rust-lang.github.io/api-guidelines/naming.html), primarily removing `get` from our getters
- fleshes out `README`
- adds [relevant `Cargo.toml` metadata to publish crate](https://doc.rust-lang.org/cargo/reference/publishing.html#before-publishing-a-new-crate)